### PR TITLE
fixing export of TableFormComponent

### DIFF
--- a/design-system/projects/kakal-ui/src/lib/kkl-ngx-table/components/table-form/table-form.component.ts
+++ b/design-system/projects/kakal-ui/src/lib/kkl-ngx-table/components/table-form/table-form.component.ts
@@ -6,7 +6,7 @@ import { QuestionBase } from '../../../form/models/question.model';
   selector: 'kkl-ngx-table-form',
   templateUrl: './table-form.component.html',
 })
-export class TableFormComponent implements OnInit  {
+export class NgxTableFormComponent implements OnInit  {
   @Input() question!: QuestionBase;
   @Input() initial!: any;
 

--- a/design-system/projects/kakal-ui/src/lib/kkl-ngx-table/kkl-ngx-table.module.ts
+++ b/design-system/projects/kakal-ui/src/lib/kkl-ngx-table/kkl-ngx-table.module.ts
@@ -26,7 +26,7 @@ import { KKLDirectivesModule } from '../directives/directives.module';
 import { NgxLocalTableComponent } from './components/local-table/local-table.component';
 import { KKLNewTableModule } from '../kkl-table/kkl-table.module';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
-import { TableFormComponent } from './components/table-form/table-form.component';
+import { NgxTableFormComponent } from './components/table-form/table-form.component';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 
@@ -34,7 +34,7 @@ import { KKLNgxPaginatorDirective } from './directives/pagination.directive';
 @NgModule({
   declarations: [
     NgxLocalTableComponent,
-    TableFormComponent,
+    NgxTableFormComponent,
     // EventTableComponent,
     // EventAdvancedSearchComponent,
     // TableFormComponent,
@@ -73,7 +73,7 @@ import { KKLNgxPaginatorDirective } from './directives/pagination.directive';
   ],
   exports: [
     NgxLocalTableComponent,
-    TableFormComponent,
+    NgxTableFormComponent,
     // EventTableComponent,
     // EventAdvancedSearchComponent,
     // TableFormComponent,

--- a/design-system/projects/kakal-ui/src/public-api.ts
+++ b/design-system/projects/kakal-ui/src/public-api.ts
@@ -164,6 +164,7 @@ export * from './lib/kkl-table/components/mei-filters/mei-filters.component';
 
 // NGX TABLE
 export * from './lib/kkl-ngx-table/kkl-ngx-table.module';
+export * from './lib/kkl-ngx-table/components/table-form/table-form.component';
 
 export * from './lib/kkl-ngx-table/components/local-table/local-table.component';
 


### PR DESCRIPTION
changing it's name to NgxTableFormComponent and including it in public api